### PR TITLE
feat: make_state_field_configurable

### DIFF
--- a/lib/fsmx.ex
+++ b/lib/fsmx.ex
@@ -3,33 +3,38 @@ defmodule Fsmx do
   """
 
   @spec transition(struct(), binary()) :: {:ok, struct} | {:error, any}
-  def transition(struct, new_state) do
+  def transition(%mod{} = struct, new_state) do
+    fsm = mod.__fsmx__()
     with {:ok, struct} <- before_transition(struct, new_state) do
-      {:ok, %{struct | state: new_state}}
+      state_field = fsm.__fsmx__(:state_field)
+      {:ok, struct |> Map.put(state_field,  new_state)}
     end
   end
 
   if Code.ensure_loaded?(Ecto) do
     @spec transition_changeset(struct(), binary, map) :: Ecto.Changeset.t()
-    def transition_changeset(%mod{state: state} = schema, new_state, params \\ %{}) do
+    def transition_changeset(%mod{} = schema, new_state, params \\ %{}) do
       fsm = mod.__fsmx__()
+      state_field = fsm.__fsmx__(:state_field)
+      state = schema |> Map.fetch!(state_field)
 
       with {:ok, schema} <- before_transition(schema, new_state) do
         schema
         |> Ecto.Changeset.change()
-        |> Ecto.Changeset.put_change(:state, new_state)
+        |> Ecto.Changeset.put_change(state_field, new_state)
         |> fsm.transition_changeset(state, new_state, params)
       else
         {:error, msg} ->
           schema
           |> Ecto.Changeset.change()
-          |> Ecto.Changeset.add_error(:state, "transition_changeset failed: #{msg}")
+          |> Ecto.Changeset.add_error(state_field, "transition_changeset failed: #{msg}")
       end
     end
 
     @spec transition_multi(Ecto.Multi.t(), struct(), any, binary, map) :: Ecto.Multi.t()
-    def transition_multi(multi, %mod{state: state} = schema, id, new_state, params \\ %{}) do
+    def transition_multi(multi, %mod{} = schema, id, new_state, params \\ %{}) do
       fsm = mod.__fsmx__()
+      state = schema |> Map.fetch!(fsm.__fsmx__(:state_field))
 
       changeset = transition_changeset(schema, new_state, params)
 
@@ -41,8 +46,9 @@ defmodule Fsmx do
     end
   end
 
-  defp before_transition(%mod{state: state} = struct, new_state) do
+  defp before_transition(%mod{} = struct, new_state) do
     fsm = mod.__fsmx__()
+    state = struct |> Map.fetch!(fsm.__fsmx__(:state_field))
     transitions = fsm.__fsmx__(:transitions)
 
     with :ok <- validate_transition(state, new_state, transitions) do

--- a/lib/fsmx/fsm.ex
+++ b/lib/fsmx/fsm.ex
@@ -32,6 +32,7 @@ defmodule Fsmx.Fsm do
 
       @fsm Keyword.get(unquote(opts), :fsm, __MODULE__)
 
+      def __fsmx__(:state_field), do: Keyword.get(unquote(opts), :state_field, :state)
       def __fsmx__(:transitions), do: Keyword.fetch!(unquote(opts), :transitions)
       def __fsmx__(:fsm), do: @fsm
     end


### PR DESCRIPTION
There are might projects having a loose state machine implementation, that could benefit from using this library, but they may have already a field configured to store state, other than the `state` field. Changing the field name may be too costly for them.

This PR feature allows configuring the field to be used for holding the state, defaulting to :state.

Consider this a WIP, since the tests are missing for the feature, have to give it a thought.