### PR TITLE
feat: Adds a new feature to permit transit to a fallback state from any state

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ defmodule App.StateMachine do
     "one" => ["two", "three"],
     "two" => ["three", "four"],
     "three" => "four",
-    "four" => :* # can transition to any state
+    "four" => :*, # can transition to any state
+    "*" => ["five"] # can transition from any state to "five"
   }
 end
 ```

--- a/lib/fsmx.ex
+++ b/lib/fsmx.ex
@@ -60,13 +60,18 @@ defmodule Fsmx do
 
   defp validate_transition(state, new_state, transitions) do
     transitions
-    |> Map.get(state, [])
+    |> from_struct_and_any(state)
     |> is_or_contains?(new_state)
     |> if do
       :ok
     else
       {:error, "invalid transition from #{state} to #{new_state}"}
     end
+  end
+
+  defp from_struct_and_any(transition, state) do
+    Map.take(transition, [state, :*])
+    |> Enum.flat_map(&elem(&1, 1))
   end
 
   defp is_or_contains?(:*, _), do: true


### PR DESCRIPTION
## Feature proposal

With the example configuration below,
we'll be able to transit from any state to the fallback state, in this case `:terminated`, 
so that we won't need to configure "allow transit to `:terminated`" by hand for every single state in the `transitions` map. 

```elixir
use Fsmx.Struct,
  state_field: :status,
  transitions: %{
    one: [:two],
    # other 100 more lines of possible states
    *: [:terminated]
  }
```