### PR TITLE
Remove IO.inspect calls for internal function

### DIFF
--- a/lib/fsmx.ex
+++ b/lib/fsmx.ex
@@ -71,12 +71,10 @@ defmodule Fsmx do
 
   defp from_source_or_fallback(transition, state) do
     Map.take(transition, [state, :*])
-    |> IO.inspect
-    |> Enum.flat_map(fn 
+    |> Enum.flat_map(fn
       {_, valid_states} when is_list(valid_states) -> valid_states
       {_, valid_state} -> [valid_state]
     end)
-    |> IO.inspect
   end
 
   defp is_or_contains?(:*, _), do: true


### PR DESCRIPTION
When adding support for fallback operators on state transition in https://github.com/subvisual/fsmx/commit/55f4939a7284eb1f632de187736d67677b66e17e, it seems like some `IO.inspect` calls were committed in an internal function. This causes all state transitions to get logged in logs and test output, which I'm guessing isn't something that most people want. This pull request removes them in case they were accidental.