### PR TITLE
Adds a default transition_changeset/4

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -10,4 +10,4 @@ config :fsmx, Fsmx.Repo,
   database: "fsmx_test",
   pool: Ecto.Adapters.SQL.Sandbox
 
-config :logger, level: :warn
+config :logger, level: :warning

--- a/lib/fsmx/fsm.ex
+++ b/lib/fsmx/fsm.ex
@@ -64,6 +64,7 @@ defmodule Fsmx.Fsm do
       def before_transition(struct, _from, _to, _state_field), do: {:ok, struct}
 
       if Code.ensure_loaded?(Ecto) do
+        def transition_changeset(changeset, _from, _to, _params), do: changeset
         def transition_changeset(changeset, _from, _to, _params, _state_field), do: changeset
         def after_transition_multi(struct, _from, _to, _state_field), do: {:ok, struct}
       end

--- a/test/fsmx/ecto_test.exs
+++ b/test/fsmx/ecto_test.exs
@@ -3,7 +3,7 @@ defmodule Fsmx.EctoTest do
 
   alias Ecto.Multi
   alias Fsmx.Repo
-  alias Fsmx.TestEctoSchemas.{Simple, WithCallbacks, WithSeparateFsm, MultiState}
+  alias Fsmx.TestEctoSchemas.{Simple, WithCallbacks, WithSeparateFsm, MultiState, WithChangesets}
 
   describe "transition_changeset/2" do
     test "returns a changeset" do
@@ -83,6 +83,16 @@ defmodule Fsmx.EctoTest do
       two = Fsmx.transition_changeset(one, "2")
 
       assert %WithSeparateFsm{before: "1"} = two.data
+    end
+  end
+
+  describe "transition/4" do
+    test "works even if you don't define all possibilities" do
+      one = %WithChangesets{state: "one"}
+
+      three = Fsmx.transition_changeset(one, "three", %{})
+
+      assert Ecto.Changeset.get_change(three, :state) == "three"
     end
   end
 

--- a/test/support/test_ecto_schemas/with_changesets.ex
+++ b/test/support/test_ecto_schemas/with_changesets.ex
@@ -1,0 +1,21 @@
+defmodule Fsmx.TestEctoSchemas.WithChangesets do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  schema "test" do
+    field(:state, :string, default: "one")
+    field(:data, :map)
+  end
+
+  use Fsmx.Struct,
+    transitions: %{
+      "one" => ["two", "three"]
+    }
+
+  def transition_changeset(changeset, "one", "two", params) do
+    changeset
+    |> cast(params, [:data])
+    |> validate_required([:data])
+  end
+end


### PR DESCRIPTION
Why:

* Fixes #17

This change addresses the need by:

* Adding a default implementation of transition_changeset/4 that we had
  removed